### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     apk add --no-cache --upgrade alpine-sdk libffi-dev ffmpeg libmagic && \
     mkdir -p {/config,$DOWNLOADS,/database} && \
     python3 -m pip install --upgrade pip && \
-    pip3 install -r /config/requirements.txt && \
+    pip3 install --no-cache-dir -r /config/requirements.txt && \
     apk del --purge alpine-sdk
 
 ENTRYPOINT ["/usr/local/bin/python3", "config/metatube.py"]


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 289.16 MB
* Image size after repair: 258.51 MB
* Difference: 30.65 MB (10.6%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks!