### PR TITLE
fix: version-lock Workzeug dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ spotipy==2.22.1
 urllib3==1.26.14
 deezer-python==5.8.1
 lyricsgenius==3.0.1
+Werkzeug==2.3.7


### PR DESCRIPTION
latest upstream Workzeug (v3+) is not supported by latest upstream flask. Locking to a v2 version so that application can run.

Without this fix we get the following error on (at least) python 3.9 on RHEL (and whatever the docker container is built on): ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.9/site-packages/werkzeug/urls.py)